### PR TITLE
[feat] add ability to use time in due date vt 

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ use {
 }
 ```
 
-You may use another plugin managers, [Plug](https://github.com/junegunn/vim-plug)
+You may use another plugin manager, [Plug](https://github.com/junegunn/vim-plug)
 for example. In that case you will still need to initialize it with lua:
 
 ```vim

--- a/README.md
+++ b/README.md
@@ -6,9 +6,7 @@ Simple plugin that provides you due for the date string.
 
 ## Requirements
 
-- Neovim Nightly (0.5)
-
-TODO: test for 0.4
+- Neovim 0.4.4+
 
 ## Installation
 
@@ -21,6 +19,15 @@ use {
     require('due_nvim').setup {}
   end
 }
+```
+
+You may use another plugin managers, [Plug](https://github.com/junegunn/vim-plug)
+for example. In that case you will still need to initialize it with lua:
+
+```vim
+lua << EOF
+require('due_nvim').setup {}
+EOF
 ```
 
 ## Settings

--- a/lua/due_nvim.lua
+++ b/lua/due_nvim.lua
@@ -41,17 +41,17 @@ local date_pattern_match
 local fulldate_pattern_match
 
 function M.setup(c)
-  prescript = c.prescript and c.prescript or 'due: '
-  prescript_hi = c.prescript_hi and c.prescript_hi or 'Comment'
-  due_hi = c.due_hi and c.due_hi or 'String'
-  ft = c.ft and c.ft or '*.md'
-  today = c.today and c.today or 'TODAY'
-  today_hi = c.today_hi and c.today_hi or 'Character'
-  overdue = c.overdue and c.overdue or 'OVERDUE'
-  overdue_hi = c.overdue_hi and c.overdue_hi or 'Error'
-  date_hi = c.date_hi and c.date_hi or 'Conceal'
-  pattern_start = c.pattern_start and c.pattern_start or '<'
-  pattern_end = c.pattern_end and c.pattern_end or '>'
+  prescript = c.prescript or 'due: '
+  prescript_hi = c.prescript_hi or 'Comment'
+  due_hi = c.due_hi or 'String'
+  ft = c.ft or '*.md'
+  today = c.today or 'TODAY'
+  today_hi = c.today_hi or 'Character'
+  overdue = c.overdue or 'OVERDUE'
+  overdue_hi = c.overdue_hi or 'Error'
+  date_hi = c.date_hi or 'Conceal'
+  pattern_start = c.pattern_start or '<'
+  pattern_end = c.pattern_end or '>'
 
   local lua_start = pattern_start:gsub("[%(%)%.%%%+%-%*%?%[%^%$%]]", "%%%1")
   local lua_end = pattern_end:gsub("[%(%)%.%%%+%-%*%?%[%^%$%]]", "%%%1")


### PR DESCRIPTION
what:
   - add two new options
      - 1. use_clock_time: this option allows the user to include the time in their due date virtual text. 
      - 2. default_due_time: if the user sets use_clock_time to true, this option sets a default due time.
         - currently, the only two options are midnight and noon
            - midnight sets the clock to 11:59:59 pm, e.g. if the user sets the due date to <01-01>, the virtual
              text will count the hours until 11:59:59 pm (23:59:59) in 01-01
            - noon does the same as above, but with noon
              
why:
   - this allows the user to have a slightly more specific due date time. It is a bandaid until a more experienced
     author allows for parsing time patterns 

known issues:
   - When use_clock_time is set to true (meaning the user can see hours, minutes, and seconds in their due time), the clock time is off when year is set forward